### PR TITLE
Ping / PingReply always returns IPStatus.TtlExpired even when timeout , unreachable or other

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3609,13 +3609,13 @@ if test "x$have_deprecated" = "xyes"; then
    AC_DEFINE(HAVE_DEPRECATED, 1, [Support for the deprecated attribute])
 fi
 
-AC_ARG_WITH(interpreter, [  --with-interpreter=yes|no       Interpreter, default=no],[buildinterpreter=$with_interpreter],[buildinterpreter=no])
-if test "x$buildinterpreter" = "xyes"; then
-    AC_DEFINE(ENABLE_INTERPRETER, 1, [Enable interpreter in the runtime.])
-    AC_MSG_NOTICE([Enable interpreter in the runtime.])
+AC_ARG_ENABLE(interpreter, [  --enable-interpreter       Enable Interpreter], enable_interpreter=$enableval, enable_interpreter=no)
+
+if test "x$enable_interpreter" = "xyes"; then
+	AC_DEFINE(ENABLE_INTERPRETER, 1, [Enable Interpreter])
 fi
 
-AM_CONDITIONAL([ENABLE_INTERPRETER], [test x$buildinterpreter != xno])
+AM_CONDITIONAL(ENABLE_INTERPRETER, [test x$enable_interpreter = xyes])
 
 
 dnl 
@@ -4613,7 +4613,7 @@ echo "
 	BigArrays:     $enable_big_arrays
 	DTrace:        $enable_dtrace
 	LLVM Back End: $enable_llvm (dynamically loaded: $enable_loadedllvm)
-	Interpreter:   $buildinterpreter
+	Interpreter:   $enable_interpreter
 
    Libraries:
 	.NET 4.x:        $with_profile4_x

--- a/mcs/class/System.Windows.Forms/System.Resources/ResXFileRef.cs
+++ b/mcs/class/System.Windows.Forms/System.Resources/ResXFileRef.cs
@@ -68,6 +68,10 @@ namespace System.Resources {
 				if (parts.Length == 1)
 					throw new ArgumentException ("value");
 
+				string filename = parts [0];
+				if (Path.DirectorySeparatorChar == '/')
+					filename = filename.Replace ("\\", "/");
+
 				Type type = Type.GetType (parts [1]);
 				if (type == typeof(string)) {
 					Encoding encoding;
@@ -77,14 +81,10 @@ namespace System.Resources {
 						encoding = Encoding.Default;
 					}
 
-					using (TextReader reader = new StreamReader(parts [0], encoding)) {
+					using (TextReader reader = new StreamReader(filename, encoding)) {
 						return reader.ReadToEnd();
 					}
 				}
-
-				string filename = parts [0];
-				if (Path.DirectorySeparatorChar == '/')
-					filename = filename.Replace ("\\", "/");
 
 				using (FileStream file = new FileStream (filename, FileMode.Open, FileAccess.Read, FileShare.Read)) {
 					buffer = new byte [file.Length];

--- a/mcs/class/System.Windows.Forms/Test/System.Resources/ResXFileRefTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Resources/ResXFileRefTest.cs
@@ -230,7 +230,6 @@ namespace MonoTests.System.Resources
 		}
 
 		[Test]
-		[Category ("NotWorking")]
 		public void ConvertFrom_Type_String_FilePathWithBackslashes ()
 		{
 			if (Path.DirectorySeparatorChar == '\\')

--- a/mcs/class/corlib/Test/System/ArrayTest.cs
+++ b/mcs/class/corlib/Test/System/ArrayTest.cs
@@ -780,6 +780,14 @@ public class ArrayTest
 	}
 
 	[Test]
+	public void CreateInstanceVoid ()
+	{
+		Assert.Throws<NotSupportedException> (delegate () {
+				Array.CreateInstance (typeof (void), 1);
+			});
+	}
+
+	[Test]
 	public void TestGetEnumerator() {
 		String[] s1 = {"this", "is", "a", "test"};
 		IEnumerator en = s1.GetEnumerator ();

--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3068,6 +3068,14 @@ namespace MonoTests.System
 			object o = Array.CreateInstance (typeof (global::System.TypedReference), 1);
 		}
 
+		[Test]
+		public void MakeArrayTypeLargeRank ()
+		{
+			Assert.Throws<TypeLoadException> (delegate () {
+					typeof (int).MakeArrayType (33);
+				});
+		}
+
 		[ComVisible (true)]
 		public class ComFoo<T> {
 		}

--- a/mcs/tools/xbuild/Makefile
+++ b/mcs/tools/xbuild/Makefile
@@ -20,8 +20,8 @@ else
 install-local: install-extras
 endif
 
-PORTABLE_TARGETS_SRC=../../../external/buildtools/src/Portable/Targets
-PCL5_FX_SRC=../../../external/buildtools/src/Portable/Frameworks/v5.0
+PORTABLE_TARGETS_SRC:=data/Portable/Targets
+PCL5_FX_SRC:=data/Portable/Frameworks/v5.0
 
 NETFRAMEWORK_DIR=$(mono_libdir)/mono/xbuild-frameworks/.NETFramework
 PCL5_FX_DIR=$(mono_libdir)/mono/xbuild-frameworks/.NETPortable/v5.0
@@ -154,6 +154,8 @@ EXTRA_DISTFILES = \
 	data/Microsoft.VisualBasic.targets \
 	data/MSBuild/Microsoft.Build.CommonTypes.xsd \
 	data/MSBuild/Microsoft.Build.Core.xsd \
+	data/Portable/Targets/* \
+	data/Portable/Frameworks/v5.0/* \
 	frameworks/net_2.0.xml \
 	frameworks/net_3.0.xml \
 	frameworks/net_3.5.xml \

--- a/mcs/tools/xbuild/data/Portable/Frameworks/v5.0/.NET Framework 4.6.xml
+++ b/mcs/tools/xbuild/data/Portable/Frameworks/v5.0/.NET Framework 4.6.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework
+    Identifier=".NETFramework"
+    Profile="*"
+    MinimumVersion="4.6"
+    Family=".NETFramework"
+    MinimumVisualStudioVersion="14.0"
+    DisplayName=".NET Framework"
+    MinimumVersionDisplayName="4.6"
+    PlatformArchitectures="AnyCPU;x86;x64"
+    IsBuiltIn="true"
+    IsHidden="false">
+    <RetargetData
+        ProjectLanguage="CSharp">
+        <NuGet
+            Identifier="net46.app"
+            PortableTargetMoniker="net452">
+            <Package
+                Identifier="Microsoft.NETCore"
+                Version="5.0.0" />
+            <Package
+                Identifier="Microsoft.NETCore.Portable.Compatibility"
+                Version="1.0.0" />
+        </NuGet>
+    </RetargetData>
+    <RetargetData
+        ProjectLanguage="VisualBasic">
+        <NuGet
+            Identifier="net46.app"
+            PortableTargetMoniker="net452">
+            <Package
+                Identifier="Microsoft.NETCore"
+                Version="5.0.0" />
+            <Package
+                Identifier="Microsoft.NETCore.Portable.Compatibility"
+                Version="1.0.0" />
+        </NuGet>
+    </RetargetData>
+</Framework>

--- a/mcs/tools/xbuild/data/Portable/Frameworks/v5.0/ASP.NET Core 1.0.xml
+++ b/mcs/tools/xbuild/data/Portable/Frameworks/v5.0/ASP.NET Core 1.0.xml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework
+    Identifier="DNXCore"
+    Profile="*"
+    MinimumVersion="5.0"
+    Family="DNXCore"
+    MinimumVisualStudioVersion="14.0"
+    DisplayName="ASP.NET Core"
+    MinimumVersionDisplayName="1.0"
+    PlatformArchitectures="AnyCPU;x86;x64"
+    IsBuiltIn="true"
+    IsHidden="true">
+    <RetargetData
+        ProjectLanguage="CSharp">
+        <NuGet
+            Identifier="dnxcore50.app">
+            <Package
+                Identifier="Microsoft.NETCore"
+                Version="5.0.0" />
+            <Package
+                Identifier="Microsoft.NETCore.Portable.Compatibility"
+                Version="1.0.0" />
+        </NuGet>
+    </RetargetData>
+    <RetargetData
+        ProjectLanguage="VisualBasic">
+        <NuGet
+            Identifier="dnxcore50.app">
+            <Package
+                Identifier="Microsoft.NETCore"
+                Version="5.0.0" />
+            <Package
+                Identifier="Microsoft.NETCore.Portable.Compatibility"
+                Version="1.0.0" />
+        </NuGet>
+    </RetargetData>
+</Framework>

--- a/mcs/tools/xbuild/data/Portable/Frameworks/v5.0/FrameworkList.xml
+++ b/mcs/tools/xbuild/data/Portable/Frameworks/v5.0/FrameworkList.xml
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FileList Redist="Microsoft-Windows-CLRCoreComp.PortableLibrary.5.0" Name=".NET Portable Subset (Visual Studio 2015)" RuntimeVersion="5.0">
+</FileList>

--- a/mcs/tools/xbuild/data/Portable/Frameworks/v5.0/Windows Universal 10.0.xml
+++ b/mcs/tools/xbuild/data/Portable/Frameworks/v5.0/Windows Universal 10.0.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework
+    Identifier=".NETCore"
+    Profile="*"
+    MinimumVersion="5.0"
+    Family="Windows"
+    MinimumVisualStudioVersion="14.0"
+    DisplayName="Windows Universal"
+    MinimumVersionDisplayName="10.0"
+    PlatformArchitectures="AnyCPU;x86;x64;ARM"
+    IsBuiltIn="true"
+    IsHidden="false">
+    <RetargetData
+        ProjectLanguage="CSharp">
+        <NuGet
+            Identifier="uwp.10.0.app"
+            PortableTargetMoniker="win81">
+            <Package
+                Identifier="Microsoft.NETCore"
+                Version="5.0.0" />
+            <Package
+                Identifier="Microsoft.NETCore.Portable.Compatibility"
+                Version="1.0.0" />
+        </NuGet>
+    </RetargetData>
+    <RetargetData
+        ProjectLanguage="VisualBasic">
+        <NuGet
+            Identifier="uwp.10.0.app"
+            PortableTargetMoniker="win81">
+            <Package
+                Identifier="Microsoft.NETCore"
+                Version="5.0.0" />
+            <Package
+                Identifier="Microsoft.NETCore.Portable.Compatibility"
+                Version="1.0.0" />
+        </NuGet>
+    </RetargetData>
+</Framework>

--- a/mcs/tools/xbuild/data/Portable/Targets/Microsoft.Portable.Core.props
+++ b/mcs/tools/xbuild/data/Portable/Targets/Microsoft.Portable.Core.props
@@ -1,0 +1,40 @@
+<!--
+***********************************************************************************************
+Microsoft.Portable.Core.props
+
+Contains common properties that are shared by all portable library projects regardless of version.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Import Project="VisualStudio\v$(VisualStudioVersion)\Microsoft.Portable.CurrentVersion.props" Condition="Exists('VisualStudio\v$(VisualStudioVersion)\Microsoft.Portable.CurrentVersion.props')"/>
+
+    <PropertyGroup>
+        <TargetPlatformIdentifier>Portable</TargetPlatformIdentifier>
+        <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+        <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
+
+        <!-- Automatically reference all assemblies in the target framework -->
+        <ImplicitlyExpandTargetFramework Condition="'$(ImplicitlyExpandTargetFramework)' == '' AND '$(PortableNuGetMode)' != 'true'">true</ImplicitlyExpandTargetFramework>
+
+    </PropertyGroup>
+
+    <!-- Redefine AssemblySearchPaths to exclude {AssemblyFolders} and {GAC}, these represent .NET-specific locations -->
+    <PropertyGroup>
+        <AssemblySearchPaths Condition="'$(AssemblySearchPaths)' == ''">
+            {CandidateAssemblyFiles};
+            $(ReferencePath);
+            {HintPathFromItem};
+            {TargetFrameworkDirectory};
+            {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
+            {RawFileName};
+            $(OutDir)
+        </AssemblySearchPaths>
+    </PropertyGroup>
+
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/Microsoft.Portable.Core.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/Microsoft.Portable.Core.targets
@@ -1,0 +1,87 @@
+<!--
+***********************************************************************************************
+Microsoft.Portable.Core.targets
+
+Contains common targets that are shared by all portable library projects regardless of version.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Import Project="VisualStudio\v$(VisualStudioVersion)\Microsoft.Portable.CurrentVersion.targets" Condition="Exists('VisualStudio\v$(VisualStudioVersion)\Microsoft.Portable.CurrentVersion.targets')"/>
+
+    <Target Name="_CheckForInvalidTargetFrameworkProfile"
+            AfterTargets="_CheckForInvalidConfigurationAndPlatform">
+
+        <Error Condition="'$(TargetFrameworkProfile)' == '' AND '$(PortableNuGetMode)' != 'true'" Text="The TargetFrameworkProfile property is not set for project '$(MSBuildProjectFile)'. Portable projects must specify a profile."/>
+
+    </Target>
+
+    <!-- 
+        To prevent framework assembly references from being unified to the ones in the full 
+        framework (for example, System.Net.Primitives, v3.9.0.0 -> System.Net.Primitives, v4.0.0.0), 
+        we set the full framework folder to the profile folder so that RAR thinks that the 
+        profile itself is the full framework. Given that we don't actually use our full framework,
+        we do not need any of the warnings from RAR that are turned off because of this.
+    -->
+    <Target Name="_SetFullFrameworkFolderToProfile"
+            AfterTargets="GetReferenceAssemblyPaths">
+
+        <PropertyGroup>
+            <_FullFrameworkReferenceAssemblyPaths>$(TargetFrameworkDirectory)</_FullFrameworkReferenceAssemblyPaths>
+        </PropertyGroup>
+    </Target>
+
+    <PropertyGroup>
+        <ResolveReferencesDependsOn>
+            $(ResolveReferencesDependsOn);
+            ImplicitlyExpandTargetFramework;
+        </ResolveReferencesDependsOn>
+
+        <ImplicitlyExpandTargetFrameworkDependsOn>
+            $(ImplicitlyExpandTargetFrameworkDependsOn);
+            GetReferenceAssemblyPaths
+        </ImplicitlyExpandTargetFrameworkDependsOn>
+
+    </PropertyGroup>
+
+    <!--
+        The ImplicitlyExpandTargetFramework target will expand all 
+        of the dll reference assemblies in the TargetFrameworkDirectory 
+        for the project and place the items into the ReferencePath itemgroup 
+        which contains resolved items.
+    -->
+
+    <Target Name="ImplicitlyExpandTargetFramework"
+        Condition="'$(ImplicitlyExpandTargetFramework)' == 'true'"
+        DependsOnTargets="$(ImplicitlyExpandTargetFrameworkDependsOn)"
+    >
+        <ItemGroup>
+            <ReferenceAssemblyPaths Include="$(_TargetFrameworkDirectories)"/>
+            <ReferencePath Include="%(ReferenceAssemblyPaths.Identity)*.dll">
+                <WinMDFile>false</WinMDFile>
+                <CopyLocal>false</CopyLocal>
+                <ReferenceGroupingDisplayName>.NET</ReferenceGroupingDisplayName>
+                <ReferenceGrouping>$(TargetFrameworkIdentifier),$(TargetFrameworkVersion)</ReferenceGrouping>
+                <ResolvedFrom>ImplicitlyExpandTargetFramework</ResolvedFrom>
+                <IsSystemReference>True</IsSystemReference>
+            </ReferencePath>
+        </ItemGroup>
+
+        <Message Importance="Low" Text="TargetMonikerDisplayName: $(TargetFrameworkMonikerDisplayName) ReferenceAssemblyPaths: @(ReferenceAssemblyPaths)"/>
+
+        <Message Importance="Low" Text="Including @(ReferencePath)"
+          Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandTargetFramework'"/>
+
+        <ItemGroup>
+            <_ResolveAssemblyReferenceResolvedFiles Include="@(ReferencePath)"
+              Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandTargetFramework'"/>
+        </ItemGroup>
+    </Target>
+
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.0/Microsoft.Portable.CSharp.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.0/Microsoft.Portable.CSharp.targets
@@ -1,0 +1,20 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.CSharp.targets
+
+Contains common properties and targets that are shared by all v4.0 Portable Library C# projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Import Project="Microsoft.Portable.Common.targets" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Import Project="..\Microsoft.Portable.Core.targets" />
+    
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.0/Microsoft.Portable.Common.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.0/Microsoft.Portable.Common.targets
@@ -1,0 +1,18 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.Common.targets
+
+Contains common properties that are shared by all v4.0 Portable Library projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Import Project="..\Microsoft.Portable.Core.props" />
+
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.0/Microsoft.Portable.VisualBasic.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.0/Microsoft.Portable.VisualBasic.targets
@@ -1,0 +1,27 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.VisualBasic.targets
+
+Contains common properties and targets that are shared by all v4.0 Portable Library VB projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    
+    <PropertyGroup>
+        <!-- Embed the runtime because it is not supported on every downlevel platform -->
+        <VBRuntime>Embed</VBRuntime>
+        <NoConfig>true</NoConfig>
+        <MyType>Empty</MyType>
+    </PropertyGroup>
+
+    <Import Project="Microsoft.Portable.Common.targets" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+    <Import Project="..\Microsoft.Portable.Core.targets" />
+  
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.5/Microsoft.Portable.CSharp.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.5/Microsoft.Portable.CSharp.targets
@@ -1,0 +1,20 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.CSharp.targets
+
+Contains common properties and targets that are shared by all v4.5 Portable Library C# projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    
+    <Import Project="Microsoft.Portable.Common.targets" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Import Project="..\Microsoft.Portable.Core.targets" />
+  
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.5/Microsoft.Portable.Common.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.5/Microsoft.Portable.Common.targets
@@ -1,0 +1,18 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.Common.targets
+
+Contains common properties that are shared by all v4.5 Portable Library projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+    <Import Project="..\Microsoft.Portable.Core.props" />
+
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.5/Microsoft.Portable.VisualBasic.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.5/Microsoft.Portable.VisualBasic.targets
@@ -1,0 +1,45 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.VisualBasic.targets
+
+Contains common properties and targets that are shared by all v4.5 Portable Library VB projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <NoConfig>true</NoConfig>
+        <MyType>Empty</MyType>
+    </PropertyGroup>
+
+    <!-- Turns on VB runtime embedding if not already set and Microsoft.VisualBasic.dll does not exist in the target framework -->
+    <Target
+        Name="GetVBRuntime"
+        BeforeTargets="CoreCompile"
+        Condition="'$(VBRuntime)' == ''">
+
+        <ItemGroup>
+            <!-- Turn TargetFrameworkDirectory (which is a property with one or more directories) into an item -->
+            <_VBRuntimeSearchDirectories Include="$(TargetFrameworkDirectory)" />
+        </ItemGroup>
+
+        <PropertyGroup>
+            <_VBRuntimeFound Condition="Exists('%(_VBRuntimeSearchDirectories.Identity)Microsoft.VisualBasic.dll')">true</_VBRuntimeFound>
+        </PropertyGroup>
+
+        <PropertyGroup Condition="$(_VBRuntimeFound) != 'true'">
+            <VBRuntime>Embed</VBRuntime>
+        </PropertyGroup>
+    </Target>
+
+    <Import Project="Microsoft.Portable.Common.targets" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+    <Import Project="..\Microsoft.Portable.Core.targets" />
+
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.6/Microsoft.Portable.CSharp.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.6/Microsoft.Portable.CSharp.targets
@@ -1,0 +1,23 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.CSharp.targets
+
+Contains common properties and targets that are shared by all v4.5 Portable Library C# projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <PortableEnableXamlTargets>true</PortableEnableXamlTargets>
+    </PropertyGroup>
+    
+    <Import Project="Microsoft.Portable.Common.targets" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Import Project="..\Microsoft.Portable.Core.targets" />
+  
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.6/Microsoft.Portable.Common.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.6/Microsoft.Portable.Common.targets
@@ -1,0 +1,18 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.Common.targets
+
+Contains common properties that are shared by all v4.5 Portable Library projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+    <Import Project="..\Microsoft.Portable.Core.props" />
+
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v4.6/Microsoft.Portable.VisualBasic.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v4.6/Microsoft.Portable.VisualBasic.targets
@@ -1,0 +1,49 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.VisualBasic.targets
+
+Contains common properties and targets that are shared by all v4.5 Portable Library VB projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <NoConfig>true</NoConfig>
+        <MyType>Empty</MyType>
+    </PropertyGroup>
+
+    <!-- Turns on VB runtime embedding if not already set and Microsoft.VisualBasic.dll does not exist in the target framework -->
+    <Target
+        Name="GetVBRuntime"
+        BeforeTargets="CoreCompile"
+        Condition="'$(VBRuntime)' == ''">
+
+        <ItemGroup>
+            <!-- Turn TargetFrameworkDirectory (which is a property with one or more directories) into an item -->
+            <_VBRuntimeSearchDirectories Include="$(TargetFrameworkDirectory)" />
+        </ItemGroup>
+
+        <PropertyGroup>
+            <_VBRuntimeFound Condition="Exists('%(_VBRuntimeSearchDirectories.Identity)Microsoft.VisualBasic.dll')">true</_VBRuntimeFound>
+        </PropertyGroup>
+
+        <PropertyGroup Condition="$(_VBRuntimeFound) != 'true'">
+            <VBRuntime>Embed</VBRuntime>
+        </PropertyGroup>
+    </Target>
+
+    <PropertyGroup>
+        <PortableEnableXamlTargets>true</PortableEnableXamlTargets>
+    </PropertyGroup>
+
+    <Import Project="Microsoft.Portable.Common.targets" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+    <Import Project="..\Microsoft.Portable.Core.targets" />
+
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v5.0/Microsoft.Portable.CSharp.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v5.0/Microsoft.Portable.CSharp.targets
@@ -1,0 +1,23 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.CSharp.targets
+
+Contains common properties and targets that are shared by all v5.0 Portable Library C# projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <PortableEnableXamlTargets>true</PortableEnableXamlTargets>
+    </PropertyGroup>
+    
+    <Import Project="Microsoft.Portable.Common.targets" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Import Project="..\Microsoft.Portable.Core.targets" />
+  
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v5.0/Microsoft.Portable.Common.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v5.0/Microsoft.Portable.Common.targets
@@ -1,0 +1,24 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.Common.targets
+
+Contains common properties that are shared by all v5.0 Portable Library projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <PortableNuGetMode>true</PortableNuGetMode>
+        <NoStdLib>true</NoStdLib>
+        <!--The build requires this list of TFMs to determine what part of the lockfile to use.
+            When it's updated in the future to no longer require it, this list can be removed. -->
+        <NuGetTargetMoniker>.NETPlatform,Version=v5.0;.NETStandard,Version=v1.0;.NETStandard,Version=v1.1;.NETStandard,Version=v1.2;.NETStandard,Version=v1.3;.NETStandard,Version=v1.4;.NETStandard,Version=v1.5;.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    </PropertyGroup>
+    <Import Project="..\Microsoft.Portable.Core.props" />
+
+</Project>

--- a/mcs/tools/xbuild/data/Portable/Targets/v5.0/Microsoft.Portable.VisualBasic.targets
+++ b/mcs/tools/xbuild/data/Portable/Targets/v5.0/Microsoft.Portable.VisualBasic.targets
@@ -1,0 +1,31 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Portable.VisualBasic.targets
+
+Contains common properties and targets that are shared by all v5.0 Portable Library VB projects.
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <NoConfig>true</NoConfig>
+        <MyType>Empty</MyType>
+    </PropertyGroup>
+
+    <!-- NuGet should add the VB Runtime -->
+
+    <PropertyGroup>
+        <PortableEnableXamlTargets>true</PortableEnableXamlTargets>
+    </PropertyGroup>
+
+    <Import Project="Microsoft.Portable.Common.targets" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+    <Import Project="..\Microsoft.Portable.Core.targets" />
+
+</Project>

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3793,13 +3793,6 @@ array_constructed:
 			MINT_IN_BREAK;
 		}
 
-		MINT_IN_CASE(MINT_LDTHISA)
-			g_error ("should not happen");
-			// sp->data.p = &frame->obj;
-			++ip;
-			++sp; 
-			MINT_IN_BREAK;
-
 #define LDARG(datamem, argtype) \
 	sp->data.datamem = * (argtype *)(frame->args + * (guint16 *)(ip + 1)); \
 	ip += 2; \

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1225,6 +1225,8 @@ mono_interp_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoOb
 	jmp_buf env;
 
 	error_init (error);
+	if (exc)
+		*exc = NULL;
 
 	frame.ex = NULL;
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1335,6 +1335,7 @@ handle_enum:
 		case MONO_TYPE_ARRAY:
 		case MONO_TYPE_SZARRAY:
 		case MONO_TYPE_OBJECT:
+		case MONO_TYPE_GENERICINST:
 			args [a_index].data.p = params [i];
 			break;
 		default:

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -325,6 +325,11 @@ get_virtual_method (MonoDomain *domain, RuntimeMethod *runtime_method, MonoObjec
 		virtual_method = mono_class_inflate_generic_method_checked (virtual_method, &context, &error);
 		mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 	}
+
+	if (virtual_method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {
+		virtual_method = mono_marshal_get_synchronized_wrapper (virtual_method);
+	}
+
 	RuntimeMethod *virtual_runtime_method = mono_interp_get_runtime_method (domain, virtual_method, &error);
 	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
 	return virtual_runtime_method;

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -76,7 +76,6 @@ OPDEF(MINT_STINARG_P, "stinarg.p", 2, MintOpUShortInt)
 OPDEF(MINT_STINARG_VT, "stinarg.vt", 4, MintOpShortAndInt)
 
 OPDEF(MINT_LDARGA, "ldarga", 2, MintOpUShortInt)
-OPDEF(MINT_LDTHISA, "ldthisa", 1, MintOpNoArgs)
 
 OPDEF(MINT_LDFLD_I1, "ldfld.i1", 2, MintOpUShortInt)
 OPDEF(MINT_LDFLD_U1, "ldfld.u1", 2, MintOpUShortInt)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2717,9 +2717,15 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				klass = (MonoClass *) mono_method_get_wrapper_data (method, token + 1);
 				if (klass == mono_defaults.typehandle_class)
 					handle = &((MonoClass *) handle)->byval_arg;
+
+				if (generic_context) {
+					handle = mono_class_inflate_generic_type_checked (handle, generic_context, &error);
+					mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				}
 			} else {
 				handle = mono_ldtoken (image, token, &klass, generic_context);
 			}
+			mono_class_init (klass);
 			mt = mint_type (&klass->byval_arg);
 			g_assert (mt == MINT_TYPE_VT);
 			size = mono_class_value_size (klass, NULL);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3191,9 +3191,9 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 	}
 	g_assert (td.max_stack_height <= (header->max_stack + 1));
 
-	rtm->clauses = mono_mempool_alloc (domain->mp, header->num_clauses * sizeof(MonoExceptionClause));
+	rtm->clauses = mono_domain_alloc0 (domain, header->num_clauses * sizeof (MonoExceptionClause));
 	memcpy (rtm->clauses, header->clauses, header->num_clauses * sizeof(MonoExceptionClause));
-	rtm->code = mono_mempool_alloc (domain->mp, (td.new_ip - td.new_code) * sizeof(gushort));
+	rtm->code = mono_domain_alloc0 (domain, (td.new_ip - td.new_code) * sizeof (gushort));
 	memcpy (rtm->code, td.new_code, (td.new_ip - td.new_code) * sizeof(gushort));
 	g_free (td.new_code);
 	rtm->new_body_start = rtm->code + body_start_offset;
@@ -3209,7 +3209,7 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 	}
 	rtm->vt_stack_size = td.max_vt_sp;
 	rtm->alloca_size = rtm->locals_size + rtm->args_size + rtm->vt_stack_size + rtm->stack_size;
-	rtm->data_items = mono_mempool_alloc (domain->mp, td.n_data_items * sizeof (td.data_items [0]));
+	rtm->data_items = mono_domain_alloc0 (domain, td.n_data_items * sizeof (td.data_items [0]));
 	memcpy (rtm->data_items, td.data_items, td.n_data_items * sizeof (td.data_items [0]));
 	g_free (td.in_offsets);
 	g_free (td.forward_refs);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1070,15 +1070,9 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 			break;
 		case CEE_LDARGA_S: {
 			/* NOTE: n includes this */
-			int n = ((guint8 *)td.ip)[1];
-			if (n == 0 && signature->hasthis) {
-				g_error ("LDTHISA: NOPE");
-				ADD_CODE(&td, MINT_LDTHISA);
-			}
-			else {
-				ADD_CODE(&td, MINT_LDARGA);
-				ADD_CODE(&td, td.rtm->arg_offsets [n]);
-			}
+			int n = ((guint8 *) td.ip) [1];
+			ADD_CODE (&td, MINT_LDARGA);
+			ADD_CODE (&td, td.rtm->arg_offsets [n]);
 			PUSH_SIMPLE_TYPE(&td, STACK_TYPE_MP);
 			td.ip += 2;
 			break;
@@ -3039,14 +3033,8 @@ generate (MonoMethod *method, RuntimeMethod *rtm, unsigned char *is_bb_start, Mo
 				break;
 			case CEE_LDARGA: {
 				int n = read16 (td.ip + 1);
-				if (n == 0 && signature->hasthis) {
-					g_error ("LDTHISA: NOPE");
-					ADD_CODE(&td, MINT_LDTHISA);
-				}
-				else {
-					ADD_CODE(&td, MINT_LDARGA);
-					ADD_CODE(&td, td.rtm->arg_offsets [n]); /* FIX for large offsets */
-				}
+				ADD_CODE (&td, MINT_LDARGA);
+				ADD_CODE (&td, td.rtm->arg_offsets [n]); /* FIX for large offsets */
 				PUSH_SIMPLE_TYPE(&td, STACK_TYPE_MP);
 				td.ip += 3;
 				break;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -19,12 +19,10 @@ test-wrench: check-parallel
 
 aotcheck: testaot gshared-aot
 
-TEST_PROG = ../interpreter/mint
-
 JITTEST_PROG = $(if $(VALGRIND), valgrind $(VALGRIND_ARGS),) $(if $(SGEN),$(top_builddir)/mono/mini/mono-sgen,$(top_builddir)/mono/mini/mono)
 
-TEST_PROG_RUN = MONO_CFG_DIR=$(mono_build_root)/runtime/etc $(LIBTOOL) --mode=execute $(TEST_PROG)
 JITTEST_PROG_RUN = MONO_CFG_DIR=$(mono_build_root)/runtime/etc $(LIBTOOL) --mode=execute $(JITTEST_PROG)
+
 
 RUNTIME_ARGS=--config tests-config --optimize=all --debug
 
@@ -889,14 +887,17 @@ LLVM = $(filter --llvm, $(MONO_ENV_OPTIONS))
 # bug-Xamarin-5278.exe got broken by 5d26590e79da139a284459299aee95c25f4cd835
 # bug-45841-fpstack-exceptions.exe: https://bugzilla.xamarin.com/show_bug.cgi?id=47053
 # appdomain-thread-abort.exe: https://bugzilla.xamarin.com/show_bug.cgi?id=47054
-DISABLED_TESTS=			\
+KNOWN_FAILING_TESTS = \
 	delegate-async-exception.exe	\
 	bug-348522.2.exe	\
 	bug-459094.exe \
 	delegate-invoke.exe \
 	bug-Xamarin-5278.exe \
 	bug-45841-fpstack-exceptions.exe \
-	appdomain-thread-abort.exe \
+	appdomain-thread-abort.exe
+
+DISABLED_TESTS = \
+	$(KNOWN_FAILING_TESTS) \
 	$(PLATFORM_DISABLED_TESTS) \
 	$(EXTRA_DISABLED_TESTS) \
 	$(COOP_DISABLED_TESTS) \
@@ -905,6 +906,166 @@ DISABLED_TESTS=			\
 	$(if $(CI),$(CI_DISABLED_TESTS)) \
 	$(if $(CI_PR),$CI_PR_DISABLED_TESTS) \
 	$(if $(LLVM),$(LLVM_DISABLED_TESTS))
+
+INTERP_DISABLED_TESTS = \
+	$(CI_PR_DISABLED_TESTS) \
+	$(CI_DISABLED_TESTS) \
+	$(KNOWN_FAILING_TESTS) \
+	abort-cctor.exe \
+	appdomain-async-invoke.exe \
+	appdomain-exit.exe \
+	appdomain-unload-callback.exe \
+	appdomain-unload-doesnot-raise-pending-events.exe \
+	appdomain-unload.exe \
+	appdomain.exe \
+	appdomain1.exe \
+	appdomain2.exe \
+	array_load_exception.exe \
+	assembly_append_ordering.exe \
+	assemblyresolve_event4.exe \
+	async-exc-compilation.exe \
+	async-with-cb-throws.exe \
+	async_read.exe \
+	bug-10127.exe \
+	bug-18026.exe \
+	bug-27147.exe \
+	bug-2907.exe \
+	bug-323114.exe \
+	bug-327438.2.exe \
+	bug-335131.2.exe \
+	bug-349190.2.exe \
+	bug-415577.exe \
+	bug-461867.exe \
+	bug-461941.exe \
+	bug-46661.exe \
+	bug-47295.exe \
+	bug-48015.exe \
+	bug-508538.exe \
+	bug-544446.exe \
+	bug-685908.exe \
+	bug-70561.exe \
+	bug-78549.exe \
+	bug-80307.exe \
+	bug-80392.2.exe \
+	bug-81673.exe \
+	bug-81691.exe \
+	bug-82022.exe \
+	bug445361.exe \
+	bug469742.2.exe \
+	call_missing_class.exe \
+	call_missing_method.exe \
+	calliGenericTest.exe \
+	cattr-field.exe \
+	classinit3.exe \
+	cominterop.exe \
+	constant-division.exe \
+	context-static.exe \
+	cross-domain.exe \
+	delegate-async-exit.exe \
+	delegate-delegate-exit.exe \
+	delegate-exit.exe \
+	delegate-with-null-target.exe \
+	delegate.exe \
+	delegate1.exe \
+	delegate3.exe \
+	delegate5.exe \
+	delegate7.exe \
+	delegate8.exe \
+	delegate9.exe \
+	dynamic-method-access.2.exe \
+	dynamic-method-finalize.2.exe \
+	dynamic-method-resurrection.exe \
+	dynamic-method-stack-traces.exe \
+	enum.exe \
+	even-odd.exe \
+	exception18.exe \
+	field-access.exe \
+	finally_block_ending_in_dead_bb.exe \
+	gc-altstack.exe \
+	gchandles.exe \
+	generic-marshalbyref.2.exe \
+	generic-mkrefany.2.exe \
+	generic-refanyval.2.exe \
+	generic-stack-traces2.2.exe \
+	generic-type-load-exception.2.exe \
+	generic-unloading.2.exe \
+	generics-invoke-byref.2.exe \
+	generics-sharing.2.exe \
+	handleref.exe \
+	invalid-token.exe \
+	invalid_generic_instantiation.exe \
+	invoke-string-ctors.exe \
+	invoke.exe \
+	ldfld_missing_class.exe \
+	ldfld_missing_field.exe \
+	ldftn-access.exe \
+	loader.exe \
+	marshal-valuetypes.exe \
+	marshal.exe \
+	marshal2.exe \
+	marshal8.exe \
+	marshal9.exe \
+	marshalbool.exe \
+	main-returns-background-change.exe \
+	method-access.exe \
+	modules.exe \
+	monitor-abort.exe \
+	monitor-wait-abort.exe \
+	monitor.exe \
+	namedmutex-destroy-race.exe \
+	nullable_boxing.2.exe \
+	pinvoke-2.2.exe \
+	pinvoke-utf8.exe \
+	pinvoke.exe \
+	pinvoke11.exe \
+	pinvoke17.exe \
+	pinvoke2.exe \
+	pinvoke3.exe \
+	pinvoke_ppcc.exe \
+	pinvoke_ppcd.exe \
+	pinvoke_ppcf.exe \
+	pinvoke_ppci.exe \
+	pinvoke_ppcs.exe \
+	priority.exe \
+	process-unref-race.exe \
+	reference-loader.exe \
+	reload-at-bb-end.exe \
+	remoting1.exe \
+	remoting2.exe \
+	remoting3.exe \
+	remoting4.exe \
+	remoting5.exe \
+	runtime-invoke.exe \
+	runtime-invoke.gen.exe \
+	safehandle.2.exe \
+	shared-generic-synchronized.2.exe \
+	sleep.exe \
+	stackframes-async.2.exe \
+	static-constructor.exe \
+	test-inline-call-stack.exe \
+	test-tls.exe \
+	test-type-ctor.exe \
+	thread-exit.exe \
+	thread6.exe \
+	threadpool-exceptions1.exe \
+	threadpool-exceptions2.exe \
+	threadpool-exceptions3.exe \
+	threadpool-exceptions4.exe \
+	threadpool-exceptions5.exe \
+	threadpool-exceptions6.exe \
+	threadpool-exceptions7.exe \
+	threadpool.exe \
+	threadpool1.exe \
+	thunks.exe \
+	transparentproxy.exe \
+	typeload-unaligned.exe \
+	unload-appdomain-on-shutdown.exe \
+	vararg.exe \
+	vararg.exe \
+	vararg2.exe \
+	vt-sync-method.exe \
+	winx64structs.exe \
+	xdomain-threads.exe
 
 # pre-requisite test sources: files that are not test themselves
 # but that need to be compiled
@@ -1069,42 +1230,6 @@ assemblyresolve/test/asm.dll:
 TestDriver.dll:
 	$(MCS) -target:library -out:$@ $(srcdir)/../mini/TestDriver.cs $(srcdir)/../mini/TestHelpers.cs
 
-test_cs: $(TEST_PROG) $(TESTSI_CS) libtest.la
-	@failed=0; \
-	passed=0; \
-	if [ "x$$V" = "x1" ]; then dump_action="dump-output"; else dump_action="no-dump"; fi; \
-	for i in $(TESTSI_CS); do	\
-		if $(srcdir)/test-driver '$(with_mono_path) $(TEST_PROG_RUN)' $$i "$(DISABLED_TESTS)" "$${dump_action}" $(RUNTIME_ARGS); \
-		then \
-			passed=`expr $${passed} + 1`; \
-		else \
-			if [ $$? = 2 ]; then break; fi; \
-			failed=`expr $${failed} + 1`; \
-		fi \
-	done; \
-	echo; echo ".cs: $${passed} test(s) passed. $${failed} test(s) did not pass."; echo
-
-test_il: $(TEST_PROG) $(TESTSI_IL) libtest.la
-	@failed=0; \
-	passed=0; \
-	if [ "x$$V" = "x1" ]; then dump_action="dump-output"; else dump_action="no-dump"; fi; \
-	for i in $(TESTSI_IL); do	\
-		if $(srcdir)/test-driver '$(with_mono_path) $(TEST_PROG_RUN)' $$i "$(DISABLED_TESTS)" "$${dump_action}" $(RUNTIME_ARGS); \
-		then \
-			passed=`expr $${passed} + 1`; \
-		else \
-			if [ $$? = 2 ]; then break; fi; \
-			failed=`expr $${failed} + 1`; \
-		fi \
-	done; \
-	echo; echo ".il: $${passed} test(s) passed. $${failed} test(s) did not pass."; echo
-
-testb: $(TEST_PROG) $(TESTBS)
-	if [ "x$$V" = "x1" ]; then dump_action="dump-output"; else dump_action="no-dump"; fi; \
-	for i in $(TESTBS); do	\
-		$(srcdir)/test-driver '$(with_mono_path) $(TEST_PROG_RUN)' $$i "$(DISABLED_TESTS)" "$${dump_action}" $(RUNTIME_ARGS);	\
-	done
-
 runtest: $(TESTSI_CS) $(TESTSI_IL) $(TESTBS) libtest.la $(PREREQSI_IL) $(PREREQSI_CS)
 	@failed=0; \
 	passed=0; \
@@ -1153,8 +1278,8 @@ testaot:
 testtrace:
 	@$(MAKE) RUNTIME_ARGS="$${RUNTIME_ARGS} --trace" runtest
 
-testinterp:
-	@$(MAKE) JITTEST_PROG_RUN="$(TEST_PROG_RUN)" runtest
+testinterp: test-runner.exe $(TESTSI_CS) $(TESTSI_IL) $(TESTBS) libtest.la $(PREREQSI_IL) $(PREREQSI_CS)
+	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) $(TEST_RUNNER_ARGS) -j a --runtime-args "--interpreter" --testsuite-name "runtime-interp" --timeout 300 --disabled "$(INTERP_DISABLED_TESTS)" $(TESTSI_CS) $(TESTBS) $(TESTSI_IL)
 
 testjitspeed: $(JITTEST_PROG) $(TESTBS)
 	for i in $(TESTBS); do	\

--- a/mono/tests/test-runner.cs
+++ b/mono/tests/test-runner.cs
@@ -140,13 +140,6 @@ public class TestRunner
 					}
 					inputFile = args [i + 1];
 					i += 2;
-				} else if (args [i] == "--runtime") {
-					if (i + 1 >= args.Length) {
-						Console.WriteLine ("Missing argument to --runtime command line option.");
-						return 1;
-					}
-					runtime = args [i + 1];
-					i += 2;
 				} else if (args [i] == "--mono-path") {
 					if (i + 1 >= args.Length) {
 						Console.WriteLine ("Missing argument to --mono-path command line option.");

--- a/mono/tests/test-runner.cs
+++ b/mono/tests/test-runner.cs
@@ -56,6 +56,7 @@ public class TestRunner
 		string runtime = "mono";
 		string config = null;
 		string mono_path = null;
+		string runtime_args = null;
 		var opt_sets = new List<string> ();
 
 		string aot_run_flags = null;
@@ -95,6 +96,13 @@ public class TestRunner
 						return 1;
 					}
 					runtime = args [i + 1];
+					i += 2;
+				} else if (args [i] == "--runtime-args") {
+					if (i + 1 >= args.Length) {
+						Console.WriteLine ("Missing argument to --runtime-args command line option.");
+						return 1;
+					}
+					runtime_args = args [i + 1];
 					i += 2;
 				} else if (args [i] == "--config") {
 					if (i + 1 >= args.Length) {
@@ -315,11 +323,11 @@ public class TestRunner
 						test_invoke = test;
 
 					/* Spawn a new process */
-					string process_args;
-					if (opt_set == null)
-						process_args = test_invoke;
-					else
-						process_args = "-O=" + opt_set + " " + test_invoke;
+					string process_args = test_invoke;
+					if (opt_set != null)
+						process_args = "-O=" + opt_set + " " + process_args;
+					if (runtime_args != null)
+						process_args = runtime_args + " " + process_args;
 
 					ProcessStartInfo info = new ProcessStartInfo (runtime, process_args);
 					info.UseShellExecute = false;

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -32,7 +32,7 @@ elif [[ ${CI_TAGS} == *'hybridaot'* ]];          then EXTRA_CONF_FLAGS="${EXTRA_
 elif [[ ${CI_TAGS} == *'winaot'* ]];             then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime_preset=winaot";
 elif [[ ${CI_TAGS} == *'aot'* ]];                then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime_preset=aot";
 elif [[ ${CI_TAGS} == *'bitcode'* ]];            then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime_preset=bitcode";
-elif [[ ${CI_TAGS} == *'interpreter'* ]];        then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-interpreter=yes";
+elif [[ ${CI_TAGS} == *'interpreter'* ]];        then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-interpreter";
 elif [[ ${CI_TAGS} == *'acceptance-tests'* ]];   then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --prefix=${MONO_REPO_ROOT}/tmp/mono-acceptance-tests --with-sgen-default-concurrent=yes";
 elif [[ ${label} != w* ]] && [[ ${label} != 'debian-8-ppc64el' ]] && [[ ${label} != 'centos-s390x' ]] && [[ ${CI_TAGS} != *'monolite'* ]];
     then

--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -3,3 +3,5 @@
 export TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
 
 ${TESTCMD} --label=interpreter-regression --timeout=10m make -C mono/mini richeck
+${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j4 tests
+${TESTCMD} --label=runtime-interp --timeout=160m make -w -C mono/tests -k testinterp V=1


### PR DESCRIPTION
I found a bug at mono/Ping.cs (line 339) That calls the system ping command and checks the exit code:

if (!ping.WaitForExit (timeout) || (ping.HasExited && ping.ExitCode == 2))
    status = IPStatus.TimedOut;
else if (ping.ExitCode == 0)
    status = IPStatus.Success;
else if (ping.ExitCode == 1)
    status = IPStatus.TtlExpired;
So TTL expired is set when there was no timeout, no error or success (exit code 2 or 0), and the exit code was 1.

If ping does not receive any reply packets at all it will exit with code 1. If a packet count and deadline are both specified, and fewer than count packets are received by the time the deadline has arrived, it will also exit with code 1. On other error it exits with code 2. Otherwise it exits with code 0. This makes it possible to use the exit code to see if a host is alive or not.

So a return value of 1 indicates that no response has been received (for various reasons) and the Mono implementation sets the TTL expired status in this case. I would expect that a time out status would be returned in such cases. But it seems that the timeout detection of the Mono implementation is not triggered here (e.g. because the ping command exits upon on it's own timeout before).

So there is other possible solutions:

To treat a TTL expired as host not alive (but this will then ignore ignore real TTL expired detections)